### PR TITLE
Updating scripts to handle new PIPENV commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.dccache
 env/
 venv/
 ENV/

--- a/generate-reqs-no-index.sh
+++ b/generate-reqs-no-index.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-pipenv lock -r > requirements.txt
+if  ! (pipenv requirements > requirements.txt); then
+    echo 'Trying legacy "pipenv lock -r" function.'
+    pipenv lock -r > requirements.txt
+fi
 sed -i '' -e '/^-i/d' requirements.txt

--- a/generate-reqs.sh
+++ b/generate-reqs.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-pipenv lock -r > requirements.txt
+if  ! (pipenv requirements > requirements.txt); then
+    echo 'Trying legacy "pipenv lock -r" function.'
+    pipenv lock -r > requirements.txt
+fi


### PR DESCRIPTION
Recent `pipenv` versions (e.g. version [2022.8.13](https://github.com/pypa/pipenv/releases/tag/v2022.8.13)) are now using the `requirements` subcommand and `pipenv lock -r` is now deprecated.

Both `generate-reqs-no-index.sh` and `generate-reqs.sh` are now set up to attempt to use the new `requirements` subcommand first. If the command fails, the scripts will then attempt to use the legacy `pipenv lock -r` command in the event that the user's environment is using a older version of `pipenv`